### PR TITLE
default.xml: default to jethro branch and use master selectively

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
 
-  <default revision="master" sync-j="4"/>
+  <default revision="jethro" sync-j="4"/>
 
   <remote fetch="http://git.yoctoproject.org" name="yocto"/>
   <remote fetch="git://git.openembedded.org" name="oe"/>
@@ -12,14 +12,14 @@
 
   <project remote="linaro" name="openembedded/meta-linaro" path="sources/meta-linaro"/>
 
-  <project remote="github" name="openembedded/openembedded-core" path="sources/openembedded-core" revision="jethro"/>
-  <project remote="github" name="openembedded/meta-openembedded" path="sources/meta-openembedded" revision="jethro"/>
+  <project remote="github" name="openembedded/openembedded-core" path="sources/openembedded-core"/>
+  <project remote="github" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="github" name="openembedded/bitbake" path="sources/bitbake" revision="1.28"/>
   <project remote="github" name="OSSystems/meta-browser" path="sources/meta-browser"/>
   <project remote="github" name="meta-qt5/meta-qt5" path="sources/meta-qt5"/>
-  <project remote="github" name="96boards/meta-96boards" path="sources/meta-96boards"/>
-  <project remote="github" name="96boards/meta-rpb" path="sources/meta-rpb"/>
-  <project remote="github" name="ndechesne/meta-qcom" path="sources/meta-qcom" revision="jethro">
+  <project remote="github" name="96boards/meta-96boards" path="sources/meta-96boards" revision="master"/>
+  <project remote="github" name="96boards/meta-rpb" path="sources/meta-rpb" revision="master"/>
+  <project remote="github" name="ndechesne/meta-qcom" path="sources/meta-qcom">
       <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
 


### PR DESCRIPTION
the manifest is supposed to track the 'stable' branch of OE layers. We only want
to use master for a selected number of layers.

Change-Id: I2c5b2021b22459de61e66ace98ae1c68c195edc2
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>