### PR TITLE
setup-environment-internal: add support for BSP's EULA

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -202,6 +202,79 @@ TMPDIR = "${OEROOT}/${_BUILDDIR}/tmp-${DISTRO_DIRNAME}"
 _EOF
 fi
 
+# Handle EULA , if needed. This is a generic method to handle BSPs
+# that might (or not) come with a EULA. If a machine has a EULA, we
+# assume that its corresponding layers has conf/EULA/$MACHINE file
+# with the EULA text, which we will display to the user and request
+# for acceptance. If accepted, the variable ACCEPT_EULA_$MACHINE is
+# set to 1 in auto.conf, which can later be used by the BSP.
+# If the env variable EULA_$MACHINE is set it is used by default,
+# without prompting the user.
+# FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
+EULA=$(find ../sources -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro)
+
+if [ -n "$EULA" ]; then
+
+    # remove '-' since we are constructing a bash variable name here
+    EULA_MACHINE="EULA_$(echo $MACHINE | sed 's/-//g')"
+
+    # NOTE: indirect reference / dynamic variable
+    if [ -n "${!EULA_MACHINE}" ]; then
+        # the EULA_$MACHINE variable is set in the environment, so we just configure
+        # ACCEPT_EULA_$MACHINE in auto.conf
+        echo "ACCEPT_EULA_$MACHINE = \"${!EULA_MACHINE}\"" >> conf/auto.conf
+    else
+        # so we need to ask user if he/she accepts the EULA:
+        cat <<EOF
+
+The BSP for $MACHINE depends on packages and firmware which are covered by an End
+User License Agreement (EULA). To have the right to use these binaries
+in your images, you need to read and accept the following...
+
+EOF
+
+        echo
+        REPLY=
+        while [ -z "$REPLY" ]; do
+            echo -n "Do you read the EULA ? (y/n) "
+            read REPLY
+            case "$REPLY" in
+                y|Y)
+                    READ_EULA=1
+                    ;;
+                n|N)
+                    READ_EULA=0
+                    ;;
+                *)
+                    REPLY=
+                    ;;
+            esac
+        done
+
+        if [ "$READ_EULA" == 1 ]; then
+            more -d ${EULA}
+            echo
+            REPLY=
+            while [ -z "$REPLY" ]; do
+                echo -n "Do you accept the EULA you just read? (y/n) "
+                read REPLY
+                case "$REPLY" in
+                    y|Y)
+                        echo "EULA has been accepted."
+                        echo "ACCEPT_EULA_$MACHINE = \"1\"" >> conf/auto.conf
+                        ;;
+                    n|N)
+                        echo "EULA has not been accepted."
+                        ;;
+                    *)
+                        REPLY=
+                        ;;
+                esac
+            done
+        fi
+    fi
+fi
+
 cat <<EOF
 
 Welcome to OpenEmbedded Reference Platform Build (OE RPB)


### PR DESCRIPTION
Some BSP might need EULA to be accepted, such as for example the BSP from
meta-qcom. This is a generic implementation of the EULA mechanism. If a BSP
needs a EULA, it needs to provide the EULA text file as conf/EULA/$MACHINE. In
which case the text will be presented to the user, who can decide to accept it
or not.

When accepted, the variable ACCEPT_EULA_$MACHINE is set to '1' in auto.conf, and
it can be used by the BSP layer.

For automation and CI, it is possible to preset the value of
ACCEPT_EULA_$MACHINE, by setting EULA_$MACHINE in the environment, before
calling setup-environment scripts.

Change-Id: I9fead8a8390bdee20d56cb3d22fa2ba3f42f2371
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>