### PR TITLE
setup-environment-internal: do not fait when EULA is not used

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -211,7 +211,7 @@ fi
 # If the env variable EULA_$MACHINE is set it is used by default,
 # without prompting the user.
 # FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
-EULA=$(find ../sources -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro)
+EULA=$(find ../sources -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
 
 if [ -n "$EULA" ]; then
 


### PR DESCRIPTION
The logic we used to detec whether a EULA is needed or not relies on:

find ../sources -print | grep "conf/eula/$MACHINE"

However, when there is no EULA for a specific MACHINE, grep will return
an error code, and if setup-environment script is called with 'set -e', then it
will fail/abort, which is unexpected. We need this specific command to always
return 0, whether the EULA exists or not, this is what this commit is about.

Change-Id: I2520db42d6232ff12eee841b1ef1bf71fe210443
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>