### PR TITLE
setup-environment-internal: remove unused line

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -83,7 +83,6 @@ fi
 
 # create a common list of "<distro>(<layer>)", sorted by <distro>
 # Blacklist OE-core and meta-linaro, we only want 96boards + vendor layers
-DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' | awk -F'/' '{print $NF "(" $2 ")"}' | sort)
 DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/distro/' '{print $NF "(" $1 ")"}' | sort)
 
 if [ -z "${DISTRO}" ]; then


### PR DESCRIPTION
this line is a left over from a4fa50ac636a8982660d856c9a6a2f652c789cf1, and it
should have been removed in this commit.

Change-Id: I18abf19365ccc1c59644bef72bd692f2f0467fb8
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>