### PR TITLE
put OE metadata into 'layers' directory

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -9,40 +9,40 @@ BBFILES = ""
 
 # These layers hold recipe metadata not found in OE-core, but lack any machine or distro content
 BASELAYERS ?= " \
-  ${OEROOT}/sources/meta-openembedded/meta-oe \
-  ${OEROOT}/sources/meta-openembedded/meta-gnome \
-  ${OEROOT}/sources/meta-openembedded/meta-xfce \
-  ${OEROOT}/sources/meta-openembedded/meta-initramfs \
-  ${OEROOT}/sources/meta-openembedded/meta-multimedia \
-  ${OEROOT}/sources/meta-openembedded/meta-networking \
-  ${OEROOT}/sources/meta-openembedded/meta-webserver \
-  ${OEROOT}/sources/meta-openembedded/meta-ruby \
-  ${OEROOT}/sources/meta-openembedded/meta-filesystems \
-  ${OEROOT}/sources/meta-openembedded/meta-perl \
-  ${OEROOT}/sources/meta-openembedded/meta-python \
-  ${OEROOT}/sources/meta-browser \
-  ${OEROOT}/sources/meta-qt5 \
+  ${OEROOT}/layers/meta-openembedded/meta-oe \
+  ${OEROOT}/layers/meta-openembedded/meta-gnome \
+  ${OEROOT}/layers/meta-openembedded/meta-xfce \
+  ${OEROOT}/layers/meta-openembedded/meta-initramfs \
+  ${OEROOT}/layers/meta-openembedded/meta-multimedia \
+  ${OEROOT}/layers/meta-openembedded/meta-networking \
+  ${OEROOT}/layers/meta-openembedded/meta-webserver \
+  ${OEROOT}/layers/meta-openembedded/meta-ruby \
+  ${OEROOT}/layers/meta-openembedded/meta-filesystems \
+  ${OEROOT}/layers/meta-openembedded/meta-perl \
+  ${OEROOT}/layers/meta-openembedded/meta-python \
+  ${OEROOT}/layers/meta-browser \
+  ${OEROOT}/layers/meta-qt5 \
 "
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
-  ${OEROOT}/sources/meta-qcom \
-  ${OEROOT}/sources/meta-96boards \
+  ${OEROOT}/layers/meta-qcom \
+  ${OEROOT}/layers/meta-96boards \
 "
 
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
-  ${OEROOT}/sources/meta-linaro/meta-linaro \
-  ${OEROOT}/sources/meta-linaro/meta-linaro-toolchain \
-  ${OEROOT}/sources/meta-linaro/meta-aarch64 \
-  ${OEROOT}/sources/meta-backports \
+  ${OEROOT}/layers/meta-linaro/meta-linaro \
+  ${OEROOT}/layers/meta-linaro/meta-linaro-toolchain \
+  ${OEROOT}/layers/meta-linaro/meta-aarch64 \
+  ${OEROOT}/layers/meta-backports \
 "
 
 BBLAYERS = " \
-  ${OEROOT}/sources/meta-rpb \
+  ${OEROOT}/layers/meta-rpb \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \
-  ${OEROOT}/sources/openembedded-core/meta \
+  ${OEROOT}/layers/openembedded-core/meta \
 "

--- a/default.xml
+++ b/default.xml
@@ -10,17 +10,17 @@
   <remote fetch="http://git.linaro.org" name="linaro"/>
   <remote fetch="http://git.shr-project.org" name="shr"/>
 
-  <project remote="linaro" name="openembedded/meta-linaro" path="sources/meta-linaro"/>
-  <project remote="linaro" name="openembedded/meta-backports" path="sources/meta-backports"/>
+  <project remote="linaro" name="openembedded/meta-linaro" path="layers/meta-linaro"/>
+  <project remote="linaro" name="openembedded/meta-backports" path="layers/meta-backports"/>
 
-  <project remote="github" name="openembedded/openembedded-core" path="sources/openembedded-core"/>
-  <project remote="github" name="openembedded/meta-openembedded" path="sources/meta-openembedded"/>
-  <project remote="github" name="openembedded/bitbake" path="sources/bitbake" revision="1.28"/>
-  <project remote="github" name="OSSystems/meta-browser" path="sources/meta-browser"/>
-  <project remote="github" name="meta-qt5/meta-qt5" path="sources/meta-qt5"/>
-  <project remote="github" name="96boards/meta-96boards" path="sources/meta-96boards" revision="master"/>
-  <project remote="github" name="96boards/meta-rpb" path="sources/meta-rpb" revision="master"/>
-  <project remote="github" name="ndechesne/meta-qcom" path="sources/meta-qcom">
+  <project remote="github" name="openembedded/openembedded-core" path="layers/openembedded-core"/>
+  <project remote="github" name="openembedded/meta-openembedded" path="layers/meta-openembedded"/>
+  <project remote="github" name="openembedded/bitbake" path="layers/bitbake" revision="1.28"/>
+  <project remote="github" name="OSSystems/meta-browser" path="layers/meta-browser"/>
+  <project remote="github" name="meta-qt5/meta-qt5" path="layers/meta-qt5"/>
+  <project remote="github" name="96boards/meta-96boards" path="layers/meta-96boards" revision="master"/>
+  <project remote="github" name="96boards/meta-rpb" path="layers/meta-rpb" revision="master"/>
+  <project remote="github" name="ndechesne/meta-qcom" path="layers/meta-qcom">
       <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
 

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -52,7 +52,7 @@ fi
 
 # create a common list of "<machine>(<layer>)", sorted by <machine>
 # Blacklist OE-core and meta-linaro, we only want 96boards + vendor layers
-MACHLAYERS=$(find sources -print | grep "conf/machine/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/sources\///' | awk -F'/conf/machine/' '{print $NF "(" $1 ")"}' | sort)
+MACHLAYERS=$(find layers -print | grep "conf/machine/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/machine/' '{print $NF "(" $1 ")"}' | sort)
 
 if [ -z "${MACHINE}" ]; then
     # whiptail
@@ -83,8 +83,8 @@ fi
 
 # create a common list of "<distro>(<layer>)", sorted by <distro>
 # Blacklist OE-core and meta-linaro, we only want 96boards + vendor layers
-DISTROLAYERS=$(find sources -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' | awk -F'/' '{print $NF "(" $2 ")"}' | sort)
-DISTROLAYERS=$(find sources -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/sources\///' | awk -F'/conf/distro/' '{print $NF "(" $1 ")"}' | sort)
+DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' | awk -F'/' '{print $NF "(" $2 ")"}' | sort)
+DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/distro/' '{print $NF "(" $1 ")"}' | sort)
 
 if [ -z "${DISTRO}" ]; then
     # whiptail
@@ -145,7 +145,7 @@ fi
 # Clean up PATH, because if it includes tokens to current directories somehow,
 # wrong binaries can be used instead of the expected ones during task execution
 export PATH=$(echo ${PATH} | sed 's/\(:.\|:\)*:/:/g;s/^.\?://;s/:.\?$//')
-export PATH="${OEROOT}"/sources/openembedded-core/scripts:"${OEROOT}"/sources/bitbake/bin:"${OEROOT}"/.repo/repo:"${PATH}"
+export PATH="${OEROOT}"/layers/openembedded-core/scripts:"${OEROOT}"/layers/bitbake/bin:"${OEROOT}"/.repo/repo:"${PATH}"
 #remove duplicate path entries
 export PATH=$(echo $PATH | awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' | sed 's/:$//')
 # Make sure Bitbake doesn't filter out the following variables from our
@@ -172,7 +172,7 @@ ln -sf "${MANIFESTS}"/conf/local.conf conf/local.conf
 ln -sf "${MANIFESTS}"/conf/bblayers.conf conf/bblayers.conf
 ln -sf "${MANIFESTS}"/README.md README.md
 
-ln -sf "${MANIFESTS}" "${OEROOT}"/sources/
+ln -sf "${MANIFESTS}" "${OEROOT}"/layers/
 
 repo start work --all
 
@@ -211,7 +211,7 @@ fi
 # If the env variable EULA_$MACHINE is set it is used by default,
 # without prompting the user.
 # FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
-EULA=$(find ../sources -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro)
+EULA=$(find ../layers -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro)
 
 if [ -n "$EULA" ]; then
 


### PR DESCRIPTION
The directory in which the OE metadata layers are stored should, more
correctly, be named 'layers' to distinguish it from the DL_DIR which is named
'sources' (since that is where the package sources are found).

Prior to this change the top-level directory layout was:
.
|-- build-rpb
|-- setup-environment -> .repo/manifests/setup-environment
`-- sources
    |-- bitbake
    |-- downloads
    |-- meta-96boards
    |-- meta-backports
    ...

After this change the top-level directory layout is:
.
|-- build-rpb
|-- layers
|   |-- bitbake
|   |-- meta-96boards
|   |-- meta-backports
|   ...
|-- setup-environment -> .repo/manifests/setup-environment
`-- sources

Signed-off-by: Trevor Woerner <twoerner@gmail.com>