### PR TITLE
setup-environment-internal: list RPB images

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -290,6 +290,9 @@ Your build environemnt has been configured with:
 You can now run 'bitbake <target>'
 
 Some of common targets are:
+    rpb-console-image
+    rpb-desktop-image
+    rpb-wayland-image
     core-image-base
     core-image-minimal
 


### PR DESCRIPTION
When the script gives suggestions for what images to build, add in the RPB
images too.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>