### PR TITLE
setup-environment-internal: phrasing

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -235,7 +235,7 @@ EOF
         echo
         REPLY=
         while [ -z "$REPLY" ]; do
-            echo -n "Do you read the EULA ? (y/n) "
+            echo -n "Would you like to read the EULA ? (y/n) "
             read REPLY
             case "$REPLY" in
                 y|Y)


### PR DESCRIPTION
Fix the phrasing of the EULA-read message.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>