### PR TITLE
setup-environment-internal: use a cleanup trap

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -19,3 +19,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 . .repo/manifests/setup-environment-internal
+
+trap RETURN
+unset RPBcleanup

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -19,6 +19,17 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 
+RPBcleanup() {
+	unset MACHINETABLE MACHLAYERS DISTROTABLE DISTROLAYERS DISTRO_DIRNAME OEROOT
+	unset ITEM MANIFESTS EULA EULA_MACHINE REPLY READ_EULA
+	unset usage oldmach
+
+	if [ -n "$BUILDDIR" ]; then
+		export BUILDDIR
+	fi
+}
+trap RPBcleanup RETURN
+
 if [ "$(whoami)" = "root" ]; then
     echo "ERROR: do not use the BSP as root. Exiting..."
     return
@@ -292,8 +303,3 @@ Some of common targets are:
     core-image-minimal
 
 EOF
-
-unset MACHINETABLE MACHLAYERS DISTROTABLE DISTROLAYERS DISTRO_DIRNAME OEROOT
-unset ITEM MANIFESTS EULA EULA_MACHINE REPLY READ_EULA
-unset oldmach
-export BUILDDIR


### PR DESCRIPTION
Install a trap handler to cleanup all defined objects, even in the case of an
early return due to error.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>