### PR TITLE
default: remove meta-backport

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,6 @@
   <remote fetch="http://git.shr-project.org" name="shr"/>
 
   <project remote="linaro" name="openembedded/meta-linaro" path="layers/meta-linaro"/>
-  <project remote="linaro" name="openembedded/meta-backports" path="layers/meta-backports"/>
 
   <project remote="github" name="openembedded/openembedded-core" path="layers/openembedded-core"/>
   <project remote="github" name="openembedded/meta-openembedded" path="layers/meta-openembedded"/>


### PR DESCRIPTION
meta-backport is not needed for 'master' branch builds, and it is confusing to
have it.

Change-Id: I2f12a934a448c9a2f3ce4d0b8c4ed70d2b129b71
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>