### PR TITLE
default.xml: lock meta-browser to a specific SRCREV

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -16,7 +16,7 @@
   <project remote="github" name="openembedded/openembedded-core" path="layers/openembedded-core"/>
   <project remote="github" name="openembedded/meta-openembedded" path="layers/meta-openembedded"/>
   <project remote="github" name="openembedded/bitbake" path="bitbake" revision="1.30"/>
-  <project remote="github" name="OSSystems/meta-browser" path="layers/meta-browser"/>
+  <project remote="github" name="OSSystems/meta-browser" path="layers/meta-browser" revision="1b4f1e588b1901d8919ea2362b0fcba37c5023e0" />
   <project remote="github" name="meta-qt5/meta-qt5" path="layers/meta-qt5"/>
   <project remote="github" name="96boards/meta-96boards" path="layers/meta-96boards" revision="master"/>
   <project remote="github" name="96boards/meta-rpb" path="layers/meta-rpb" revision="master"/>


### PR DESCRIPTION
It lacks a 'krogoth' branch, which confuses 'repo sync'. Apart from that we shouldn't track master branches from repos outside our control in a 'krogoth' release setup.

Change-Id: I1e5662a498deb406ef59aa1e3bff4d87f84c37eb
Signed-off-by: Koen Kooi <koen.kooi@linaro.org>