### PR TITLE
setup-environment-internal: fix whiptail and dialog command usage

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -58,22 +58,24 @@ if [ -z "${MACHINE}" ]; then
     # whiptail
     which whiptail > /dev/null 2>&1
     if [ $? -eq 0 ]; then
+        MACHINETABLE=
         for ITEM in $MACHLAYERS; do
             MACHINETABLE="${MACHINETABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1) OFF\n"
         done
         MACHINE=$(whiptail --title "Available Machines" --radiolist \
             "Please choose a machine" 0 0 20 \
-            "${MACHINETABLE}" 3>&1 1>&2 2>&3)
+            ${MACHINETABLE} 3>&1 1>&2 2>&3)
     fi
 
     # dialog
     if [ -z "$MACHINE" ]; then
         which dialog > /dev/null 2>&1
         if [ $? -eq 0 ]; then
+            MACHINETABLE=
             for ITEM in $MACHLAYERS; do
                 MACHINETABLE="$MACHINETABLE $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1)"
             done
-            MACHINE=$(dialog --title "Available Machines" --menu "Please choose a machine" 0 0 20 "$MACHINETABLE" 3>&1 1>&2 2>&3)
+            MACHINE=$(dialog --title "Available Machines" --menu "Please choose a machine" 0 0 20 $MACHINETABLE 3>&1 1>&2 2>&3)
         fi
     fi
 fi
@@ -86,22 +88,24 @@ if [ -z "${DISTRO}" ]; then
     # whiptail
     which whiptail > /dev/null 2>&1
     if [ $? -eq 0 ]; then
+        DISTROTABLE=
         for ITEM in $DISTROLAYERS; do
             DISTROTABLE="${DISTROTABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1) OFF\n"
         done
         DISTRO=$(whiptail --title "Available Distributions" --radiolist \
             "Please choose a distribution" 0 0 20 \
-            "${DISTROTABLE}" 3>&1 1>&2 2>&3)
+            ${DISTROTABLE} 3>&1 1>&2 2>&3)
     fi
 
     # dialog
     if [ -z "$DISTRO" ]; then
         which dialog > /dev/null 2>&1
         if [ $? -eq 0 ]; then
+            DISTROTABLE=
             for ITEM in $DISTROLAYERS; do
                 DISTROTABLE="$DISTROTABLE $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1)"
             done
-            DISTRO=$(dialog --title "Available Distributions" --menu "Please choose a distribution" 0 0 20 "$DISTROTABLE" 3>&1 1>&2 2>&3)
+            DISTRO=$(dialog --title "Available Distributions" --menu "Please choose a distribution" 0 0 20 $DISTROTABLE 3>&1 1>&2 2>&3)
         fi
     fi
 


### PR DESCRIPTION
Commit a6f29ed was a bit more too aggressive.. and adding quotes when calling
whiptail or dialog was wrong. These tools expect parameters to be passed by
tupple, and adding the quotes does not work. Since this commit, sourcing the
script with MACHINE and/or DISTRO not set would result in bad things such as:

    MACHINE = Box options:
    --msgbox <text> <height> <width>
    --yesno  <text> <height> <width>
    --infobox <text> <height> <width>
    --inputbox <text> <height> <width> [init]
    --passwordbox <text> <height> <width> [init]
    --textbox <file> <height> <width>
    --menu <text> <height> <width> <listheight> [tag item] ...
    --checklist <text> <height> <width> <listheight> [tag item status]...
    --radiolist <text> <height> <width> <listheight> [tag item status]...
    --gauge <text> <height> <width> <percent>
Options: (depend on box-option)
         --clear

Also make sure that MACHINETABLE and DISTROTABLE are unset before they are
used, if the script failed once it's possible to have them partially set in the
env..

Change-Id: Ib470731e5c3fb87c4405303517ba314576d8a555
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>