### PR TITLE
setup-environment-internal: use --menu instead of --radiolist for whi…

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -59,9 +59,9 @@ if [ -z "${MACHINE}" ]; then
     which whiptail > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         for ITEM in $MACHLAYERS; do
-            MACHINETABLE="${MACHINETABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1) OFF\n"
+            MACHINETABLE="${MACHINETABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1)"
         done
-        MACHINE=$(whiptail --title "Available Machines" --radiolist \
+        MACHINE=$(whiptail --title "Available Machines" --menu \
             "Please choose a machine" 0 0 20 \
             "${MACHINETABLE}" 3>&1 1>&2 2>&3)
     fi
@@ -87,9 +87,9 @@ if [ -z "${DISTRO}" ]; then
     which whiptail > /dev/null 2>&1
     if [ $? -eq 0 ]; then
         for ITEM in $DISTROLAYERS; do
-            DISTROTABLE="${DISTROTABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1) OFF\n"
+            DISTROTABLE="${DISTROTABLE} $(echo "$ITEM" | cut -d'(' -f1) $(echo "$ITEM" | cut -d'(' -f2 | cut -d')' -f1)"
         done
-        DISTRO=$(whiptail --title "Available Distributions" --radiolist \
+        DISTRO=$(whiptail --title "Available Distributions" --menu \
             "Please choose a distribution" 0 0 20 \
             "${DISTROTABLE}" 3>&1 1>&2 2>&3)
     fi


### PR DESCRIPTION
…ptail

Using radiolist is confusing and error prone. The user has to press the space
bar to select an item, which might not be obvious. And if the user presses
'Enter' first, then the value is not set.

There is no obvious reason to use radiolist, since what we have really is a
menu. The default item will be the first one, but at least we do not end up in a
situation where no value is set.

Change-Id: If00c2040fb94573c732978e9d7c746e16253ea2a
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>