### PR TITLE
setup-environment-internal: remove 'repo start work'

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -172,8 +172,6 @@ ln -sf "${MANIFESTS}"/README.md README.md
 
 ln -sf "${MANIFESTS}" "${OEROOT}"/layers/
 
-repo start work --all
-
 DISTRO_DIRNAME=$(echo "${DISTRO}" | sed 's#[.-]#_#g')
 
 cat > conf/auto.conf <<EOF


### PR DESCRIPTION
the init script internally calls "repo start work --all" in order to create
a default branch for all repos. However this is confusing for users, since this
is done 'silently' and might in turn checkout a branch without the user being
aware.

It seems that a better approach is to let the users manage their branches as
they want or prefer.

One noticeable change after this patch, is that layer will now be in a
'detached' state, and not in a git branch.

Change-Id: I673b34e3897e6b3cebeb384b19324827595dec92
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>