### PR TITLE
local.conf: do not enable PRSERV by default

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -48,6 +48,5 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # enable PR service on build machine itself
 # its good for a case when this is the only builder
 # generating the feeds
-#
-PRSERV_HOST = "localhost:0"
+#PRSERV_HOST = "localhost:0"
 


### PR DESCRIPTION
Using PRSERV is a good idea *if* we are building an official distro and its
associated feed. It requires to save/restrore the PRSERV state to make sure we
don't break the versioning. It is not really a good idea to enable it by default
for everyone, since it can cause package numbers to go backwards.

Change-Id: I6cb10a6fb885d45b3b1b1e5bc193f52c9285239f
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>