### PR TITLE
README: fix misspelled link

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ $ repo rebase
 ```
 If you find any bugs please report them here
 
-https://github.com/96booards/oe-rpb-manifest/issues
+https://github.com/96boards/oe-rpb-manifest/issues
 
 If you have questions or feedback, please subscribe to
 


### PR DESCRIPTION
This trivial typo fix is based on master but worth applying also to current default branch krogoth