### PR TITLE
bblayers.conf: add meta-st-cannes layer to BSPLAYERS

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -26,6 +26,7 @@ BASELAYERS ?= " \
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
+  ${OEROOT}/layers/meta-st-cannes2 \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
 "


### PR DESCRIPTION
Add support for ST's Cannes SoC based B2260 96board.

Signed-off-by: Lee Jones <lee.jones@linaro.org>