### PR TITLE
Revert "bblayers.conf: add meta-st-cannes layer to BSPLAYERS"

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -26,7 +26,6 @@ BASELAYERS ?= " \
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
-  ${OEROOT}/layers/meta-st-cannes2 \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
 "


### PR DESCRIPTION
This reverts commit 3bcd667c7b1f4897b54e9224e438a8793dff526e. The
meta-st-cannes2 layer is still not publicly available, we should merge this
change only once the layer exists, otherwise it breaks the build for every
user.

Change-Id: I2375b34978ce5723433790bb17c87f481878adf4
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>