### PR TITLE
README.md: fix RPB distro name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ MACHINE values can be:
 * hikey
 
 DISTRO values can be:
-* rpb-x11
+* rpb
 * rpb-wayland
 
 ```
 $ . setup-environment
 $ MACHINE=<machine> DISTRO=<distro> bitbake <image>
 ```
-e.g. MACHINE=hikey DISTRO=rpb-x11 bitbake core-image-minimal
+e.g. MACHINE=hikey DISTRO=rpb bitbake core-image-minimal
 
 Creating a local topic branch
 -----------------------------


### PR DESCRIPTION
The master branch of meta-rpb (currently) has two distros: "rpb" and
"rpb-wayland". Change "rpb-x11" references to "rpb".

Signed-off-by: Trevor Woerner <twoerner@gmail.com>