### PR TITLE
Add support for B2260

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -26,6 +26,7 @@ BASELAYERS ?= " \
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
+  ${OEROOT}/layers/meta-st-cannes2 \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
 "

--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,8 @@
   <project remote="github" name="meta-qt5/meta-qt5" path="layers/meta-qt5"/>
   <project remote="github" name="96boards/meta-96boards" path="layers/meta-96boards" revision="master"/>
   <project remote="github" name="96boards/meta-rpb" path="layers/meta-rpb" revision="master"/>
-  <project remote="github" name="ndechesne/meta-qcom" path="layers/meta-qcom">
+  <project remote="github" name="ndechesne/meta-qcom" path="layers/meta-qcom"/>
+  <project remote="github" name="cpriouzeau/meta-st-cannes2" path="layers/meta-st-cannes2">
       <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
 


### PR DESCRIPTION
Now that we have pushed the meta-st-cannes2 layer publicly, let's link to it.