### PR TITLE
setup-environment: fix issue when several machine start with same name

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -218,7 +218,7 @@ fi
 # If the env variable EULA_$MACHINE is set it is used by default,
 # without prompting the user.
 # FIXME: there is a potential issue if the same $MACHINE is set in more than one layer.. but we should assert that earlier
-EULA=$(find ../layers -print | grep "conf/eula/$MACHINE" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
+EULA=$(find ../layers -path "*/conf/eula/$MACHINE" -print | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro || true)
 
 if [ -n "$EULA" ]; then
 


### PR DESCRIPTION
The current 'find' command was confused because we have dragonboard410c and
dragonboard410c-32 now, and it would pick both. Instead of using grep to filter,
rely on find -path.

Change-Id: Ie1f9dec542c7d37aca7875b7ad07f01522293e5a
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>