### PR TITLE
setup-environment: set LANG when using sort to ensure consistent output

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -61,7 +61,7 @@ if [ $# -gt 1 ]; then
 fi
 # create a common list of "<machine>(<layer>)", sorted by <machine>
 # Blacklist OE-core and meta-linaro, we only want 96boards + vendor layers
-MACHLAYERS=$(find layers -print | grep "conf/machine/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/machine/' '{print $NF "(" $1 ")"}' | sort)
+MACHLAYERS=$(find layers -print | grep "conf/machine/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/machine/' '{print $NF "(" $1 ")"}' | LANG=C sort)
 
 if [ -z "${MACHINE}" ]; then
     # whiptail
@@ -91,7 +91,7 @@ fi
 
 # create a common list of "<distro>(<layer>)", sorted by <distro>
 # Blacklist OE-core and meta-linaro, we only want 96boards + vendor layers
-DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/distro/' '{print $NF "(" $1 ")"}' | sort)
+DISTROLAYERS=$(find layers -print | grep "conf/distro/.*\.conf" | grep -v scripts | grep -v openembedded-core | grep -v meta-linaro | sed -e 's/\.conf//g' -e 's/layers\///' | awk -F'/conf/distro/' '{print $NF "(" $1 ")"}' | LANG=C sort)
 
 if [ -n "${DISTROLAYERS}" ] && [ -z "${DISTRO}" ]; then
     # whiptail


### PR DESCRIPTION
the behavior of sort is different based on the LANG setting, so let's hardcode
it to make sure that we have a consistent output for all users. Using LANG=C
produces a slightly (subjectively) better output in our case that UTF output, e.g.

LANG=C
rpb(meta-rpb)
rpb-eglfs(meta-rpb)
rpb-wayland(meta-rpb)

LANG=en_US.UTF-8
rpb-eglfs(meta-rpb)
rpb(meta-rpb)
rpb-wayland(meta-rpb)

Change-Id: I0501157a1aef71c968960da42b3818a692dd17f2
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>