### PR TITLE
README.md: remove leading '$'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The OE RPB buildsystem is using various components from the Yocto Project, most 
 
 To configure the scripts and download the build metadata, do:
 ```
-$ mkdir ~/bin
-$ PATH=~/bin:$PATH
+mkdir ~/bin
+PATH=~/bin:$PATH
 
-$ curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-$ chmod a+x ~/bin/repo
+curl http://commondatastorage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
+chmod a+x ~/bin/repo
 ```
 Run repo init to bring down the latest version of Repo with all its most recent bug fixes. You must specify a URL for the manifest, which specifies where the various repositories included in the Android source will be placed within your working directory. To check out the current branch, specify it with -b:
 ```
-$ repo init -u https://github.com/96boards/oe-rpb-manifest.git -b master
+repo init -u https://github.com/96boards/oe-rpb-manifest.git -b master
 ```
 When prompted, configure Repo with your real name and email address.
 
@@ -24,17 +24,17 @@ A successful initialization will end with a message stating that Repo is initial
 
 To pull down the metadata sources to your working directory from the repositories as specified in the default manifest, run
 ```
-$ repo sync
+repo sync
 ```
 When downloading from behind a proxy (which is common in some corporate environments), it might be necessary to explicitly specify the proxy that is then used by repo:
 ```
-$ export HTTP_PROXY=http://<proxy_user_id>:<proxy_password>@<proxy_server>:<proxy_port>
-$ export HTTPS_PROXY=http://<proxy_user_id>:<proxy_password>@<proxy_server>:<proxy_port>
+export HTTP_PROXY=http://<proxy_user_id>:<proxy_password>@<proxy_server>:<proxy_port>
+export HTTPS_PROXY=http://<proxy_user_id>:<proxy_password>@<proxy_server>:<proxy_port>
 ```
 More rarely, Linux clients experience connectivity issues, getting stuck in the middle of downloads (typically during "Receiving objects"). It has been reported that tweaking the settings of the TCP/IP stack and using non-parallel commands can improve the situation. You need root access to modify the TCP setting:
 ```
-$ sudo sysctl -w net.ipv4.tcp_window_scaling=0
-$ repo sync -j1
+sudo sysctl -w net.ipv4.tcp_window_scaling=0
+repo sync -j1
 ```
 Setup Environment
 -----------------
@@ -48,8 +48,8 @@ DISTRO values can be:
 * rpb-wayland
 
 ```
-$ . setup-environment
-$ MACHINE=<machine> DISTRO=<distro> bitbake <image>
+. setup-environment
+MACHINE=<machine> DISTRO=<distro> bitbake <image>
 ```
 e.g. MACHINE=hikey DISTRO=rpb bitbake core-image-minimal
 
@@ -58,7 +58,7 @@ Creating a local topic branch
 
 If you need to create local branches for all repos which then can be done e.g.
 ```
-$ ~/bin/repo start myangstrom --all
+~/bin/repo start myangstrom --all
 ```
 Where 'myangstrom' is the name of branch you choose
 
@@ -67,11 +67,11 @@ Updating the sandbox
 
 If you need to bring changes from upstream then use following commands
 ```
-$ repo sync
+repo sync
 ```
 Rease your local committed changes
 ```
-$ repo rebase
+repo rebase
 ```
 If you find any bugs please report them here
 


### PR DESCRIPTION
With the '$' sign on each command line , it makes it inconvenient to copy/paste
from the web into a terminal. Since commands are already using the proper markup
tags, they are properly highlighted on the web page, so removing the '$' sign
doesn't make a bad visual impact and let users copy/paste more conveniently.

Change-Id: Id48af8f3b91e9464cd1d3e29b343b97340f0f7b1
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>