### PR TITLE
setup-environment-internal: enable rm_work by default via auto.conf

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -2,8 +2,6 @@
 # CONF_VERSION is increased each time build/conf/ changes incompatibly
 CONF_VERSION = "1"
 
-#INHERIT += "rm_work"
-
 # Which files do we want to parse:
 BBMASK = ""
 

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -246,6 +246,9 @@ cat > conf/auto.conf <<EOF
 DISTRO ?= "${DISTRO}"
 MACHINE ?= "${MACHINE}"
 SDKMACHINE ?= "${SDKMACHINE}"
+
+# Extra options that can be changed by the user
+INHERIT += "rm_work"
 EOF
 if [ ! -e conf/site.conf ]; then
     cat > conf/site.conf <<_EOF


### PR DESCRIPTION
Since auto.conf is controlled by the user, add rm_work by default
there and allow the user to easily disable if not needed/wanted.

Note that rm_work is currently defined by the rpb distro itself.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>