### PR TITLE
bblayers.conf: remove meta-aarch64 from BBLAYERS

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -37,7 +37,6 @@ BSPLAYERS ?= " \
 EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-linaro \
   ${OEROOT}/layers/meta-linaro/meta-linaro-toolchain \
-  ${OEROOT}/layers/meta-linaro/meta-aarch64 \
   ${OEROOT}/layers/meta-linaro/meta-optee \
 "
 


### PR DESCRIPTION
This layer no longer contains anything needed/useful for OE RPB.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>