### PR TITLE
local.conf: mask gstreamer-vaapi-1.0_1.8.2.bb from meta-intel

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -5,6 +5,11 @@ CONF_VERSION = "1"
 # Which files do we want to parse:
 BBMASK = ""
 
+# Mask gstreamer vaapi recipe because:
+# meta-intel layer ships gstreamer-vaapi-1.0_1.8.2.bb
+# meta-backports layer ships gstreamer1.0-vaapi_1.10.4.bb
+BBMASK += "gstreamer-vaapi-1.0_1.8.*.bb"
+
 # What kind of images do we want?
 IMAGE_FSTYPES_append = " tar.xz"
 


### PR DESCRIPTION
meta-intel layer ships gstreamer-vaapi-1.0_1.8.2.bb
meta-backports layer ships gstreamer1.0-vaapi_1.10.4.bb

It's causing a build failure:
| configure: error: Requested 'gstreamer-codecparsers-1.0 <= 1.8.99' but
 version of GStreamer codec parsers is 1.10.4

Mask the meta-intel recipe, in favor of meta-backports recipe.

Suggested-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>