### PR TITLE
default.xml: reorder to match 'repo manifest -o'

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
-
-  <default revision="pyro" sync-j="4"/>
-
-  <remote fetch="http://git.yoctoproject.org" name="yocto"/>
-  <remote fetch="git://git.openembedded.org" name="oe"/>
-  <remote fetch="https://github.com" name="github"/>
   <remote fetch="https://bitbucket.org" name="bitbucket"/>
+  <remote fetch="https://github.com" name="github"/>
   <remote fetch="http://git.linaro.org" name="linaro"/>
+  <remote fetch="git://git.openembedded.org" name="oe"/>
   <remote fetch="http://git.shr-project.org" name="shr"/>
-
-  <project remote="linaro" name="openembedded/meta-linaro" path="layers/meta-linaro"/>
-  <project remote="linaro" name="openembedded/meta-backports" path="layers/meta-backports"/>
-  <project remote="github" name="openembedded/openembedded-core" path="layers/openembedded-core"/>
-  <project remote="github" name="openembedded/meta-openembedded" path="layers/meta-openembedded"/>
-  <project remote="github" name="openembedded/bitbake" path="bitbake" revision="1.34"/>
-  <project remote="github" name="96boards/meta-96boards" path="layers/meta-96boards"/>
-  <project remote="github" name="ndechesne/meta-qcom" path="layers/meta-qcom"/>
-  <project remote="github" name="meta-qt5/meta-qt5" path="layers/meta-qt5"/>
-  <project remote="github" name="OSSystems/meta-browser" path="layers/meta-browser" revision="master"/>
-
-  <project remote="yocto" name="git/meta-virtualization" path="layers/meta-virtualization"/>
-  <project remote="yocto" name="git/meta-ti" path="layers/meta-ti" revision="master"/>
-
-  <project remote="github" name="96boards/meta-rpb" path="layers/meta-rpb">
-      <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
+  <remote fetch="http://git.yoctoproject.org" name="yocto"/>
+  
+  <default revision="pyro" sync-j="4"/>
+  
+  <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
+  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github">
+    <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-
+  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="master"/>
+  <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
+  <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
+  <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
+  <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.34"/>
+  <project name="openembedded/meta-backports" path="layers/meta-backports" remote="linaro"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
+  <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
+  <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
Re-order default.xml so it matches the output from 'repo manifest -o' in
a sync'd workspace.

This allows pinned manifests to be compared more easily.

Note, 'repo manifest -o' introduces spaces on blank lines. I left these
in to stick to the exact repo output.

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>