### PR TITLE
conf/bblayers.conf: Remove meta-ruby from meta-openembedded

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -16,7 +16,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-multimedia \
   ${OEROOT}/layers/meta-openembedded/meta-networking \
   ${OEROOT}/layers/meta-openembedded/meta-webserver \
-  ${OEROOT}/layers/meta-openembedded/meta-ruby \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \


### PR DESCRIPTION
The meta-ruby layer was removed from meta-openembedded [1] because
now is part of oe-core [2].

[1]
http://git.openembedded.org/meta-openembedded/commit/?id=6e7c9636d2
[2]
http://git.openembedded.org/openembedded-core/commit/?id=10fd3b4144

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>