### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you need to bring changes from upstream then use following commands
 ```
 repo sync
 ```
-Rease your local committed changes
+Rebase your local committed changes
 ```
 repo rebase
 ```


### PR DESCRIPTION
Hello!

Quick typo fix:  `Rease` -> `Rebase`

This could be applied to all branches, but since morty is the default branch that's what this PR is for.