### PR TITLE
default.xml: add meta-clang layer

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -22,6 +22,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-browser \
   ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
+  ${OEROOT}/layers/meta-clang \
 "
 
 # These layers hold machine specific content, aka Board Support Packages

--- a/default.xml
+++ b/default.xml
@@ -16,6 +16,7 @@
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>


### PR DESCRIPTION
This layer will enable stuff built with Clang, such as the BPF
selftests.

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>