### PR TITLE
default.xml: meta-ti: rocko branch created

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -16,7 +16,7 @@
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="26d50665e2f7223c5f4ad7481a8d2431e7cb55fb"/>
   <project name="cpriouzeau/meta-st-cannes2" path="layers/meta-st-cannes2" remote="github"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="78326e7baa308945d62a0293758df6542a875d8b"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>


### PR DESCRIPTION
meta-ti layer has rocko branch now.
It is using linux kernel 4.14, and ti-u-boot-2018.01 branch for u-boot.
If it matters, am57xx-evm.dtb is not available in ti-u-boot-2018.01: am57xx-beagle-x15.dtb + DT overlays are used for am57xx-evm instead.