### PR TITLE
default.xml, conf/bblayers.conf: Add meta-rust layer

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -19,6 +19,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
+  ${OEROOT}/layers/meta-rust \
   ${OEROOT}/layers/meta-browser \
   ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \

--- a/default.xml
+++ b/default.xml
@@ -11,6 +11,7 @@
   
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
+  <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>


### PR DESCRIPTION
Recently meta-browser [1] depends on meta-rust, I added
thud in meta-rust LAYERCOMPAT_SERIES [2].

[1] https://github.com/OSSystems/meta-browser/commit/b5fa3f5982
[2] https://github.com/meta-rust/meta-rust/commit/99ec7396f6

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>