### PR TITLE
default.xml: Add meta-intel

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -28,6 +28,7 @@ BASELAYERS ?= " \
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
+  ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
   ${OEROOT}/layers/meta-ti \

--- a/default.xml
+++ b/default.xml
@@ -15,6 +15,7 @@
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
+  <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>


### PR DESCRIPTION
This enables the following machines:
  intel-core2-32
  intel-corei7-64

Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>