### PR TITLE
default.xml: cleanup default with 'repo manifest'

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,10 @@
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
+  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="3322d838f29be9a62eea8a846f0c6d4e86ccd0ae"/>
   <project name="cpriouzeau/meta-st-cannes2" path="layers/meta-st-cannes2" remote="github"/>
+  <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="cad0618a55da9229426b66fae0cdbb2bc2dca348"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
@@ -23,7 +26,4 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
-  <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="cad0618a55da9229426b66fae0cdbb2bc2dca348" branch="master" />
-  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="3322d838f29be9a62eea8a846f0c6d4e86ccd0ae" branch="master" />
 </manifest>


### PR DESCRIPTION
Cleaned up with:
repo manifest > default.xml

As we want to stick to the same 'order' as much as possible.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>