### PR TITLE
default.xml: cleanup default with 'repo manifest'

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,10 +12,10 @@
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
+  <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>


### PR DESCRIPTION
Cleaned up with:
repo manifest > default.xml

As we want to stick to the same 'order' as much as possible.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>