### PR TITLE
default.xml: Use meta-clang warrior branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,7 @@
   
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
-  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github" revision="master"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>


### PR DESCRIPTION
In upstream thud and warrior support on master was removed.

https://github.com/kraj/meta-clang/commit/df21a7d3f29cb49783ff93a9f5ba947832a09e25

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>