### PR TITLE
default.xml: Use meta-clang warrior branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,7 +19,7 @@
   </project>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
-  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github" revision="master"/>
+  <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github" revision="master"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>


### PR DESCRIPTION
In upstream thud and warrior support on master was removed.

https://github.com/kraj/meta-clang/commit/df21a7d3f29cb49783ff93a9f5ba947832a09e25

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>