### PR TITLE
Add meta-measured layer

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -25,6 +25,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \
   ${OEROOT}/layers/meta-selinux \
+  ${OEROOT}/layers/meta-measured \
 "
 
 # These layers hold machine specific content, aka Board Support Packages

--- a/default.xml
+++ b/default.xml
@@ -27,4 +27,5 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="flihp/meta-measured" path="layers/meta-measured" remote="github"/>
 </manifest>


### PR DESCRIPTION
This contains pyelftools recipe which is now required by
op-tee build.

See https://github.com/flihp/meta-measured/pull/82 which
adds python3 support.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>