### PR TITLE
default: switch meta-rpb to zeus

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <default revision="zeus" sync-j="4"/>
   
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
-  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github" revision="master"/>
+  <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
   <project name="Freescale/meta-freescale" path="layers/meta-freescale" remote="github"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>


### PR DESCRIPTION
The default manifest no longer builds due to changes in meta-rpb that replace
distro_features_check with features_check - a function that doesn't exist in
zeus.

This happens since meta-rpb commit:
65b2829  2019-12-02  Merge pull request #233 from alimon/master

Signed-off-by: Ryan Harkin <ryan.harkin@linaro.org>