### PR TITLE
Add meta-python2 layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ In this wiki, we assume that the reader is familiar with basic concepts of OpenE
 | meta-96boards | This support layer is managed by Linaro and intended for boards that do not have their own board support layer. Currently used for the HiKey Consumer Edition board, and eventually the Bubblegum-96 board. If a vendor does not support their own layer, it can be added to this layer. |
 | meta-qcom | This is the board support layer for Qualcomm boards. Currently supports IFC6410 and the DragonBoard 410c. |
 | meta-st-cannes2 | This is the board support layer for ST B2260 board. |
+| meta-python2 | This layer provides support of Python 2.x in recent OE versions after EOL. |
 
 ## oe-rpb-manifest repository
 

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -25,6 +25,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \
   ${OEROOT}/layers/meta-selinux \
+  ${OEROOT}/layers/meta-python2 \
 "
 
 # These layers hold machine specific content, aka Board Support Packages

--- a/default.xml
+++ b/default.xml
@@ -28,4 +28,5 @@
   <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
+  <project name="meta-python2" path="layers/meta-python2" remote="oe"/>
 </manifest>


### PR DESCRIPTION
Some layers like meta-rpb (packagegroups) and meta-browser still
depends on Python 2.x.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>