### PR TITLE
meta-browser: remove layer from zeus build

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -20,7 +20,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-rust \
-  ${OEROOT}/layers/meta-browser \
   ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \

--- a/default.xml
+++ b/default.xml
@@ -11,7 +11,6 @@
   
   <project name="96boards/meta-96boards" path="layers/meta-96boards" remote="github"/>
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
-  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
   <project name="Freescale/meta-freescale" path="layers/meta-freescale" remote="github"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="master"/>


### PR DESCRIPTION
meta-browser doesn't have a zeus branch and master now
has changes which cause parse errors on zeus.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>