### PR TITLE
default.xml: Use meta-linaro zeus branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -23,7 +23,7 @@
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.44"/>
   <project name="openembedded/meta-backports" path="layers/meta-backports" remote="linaro"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro" revision="master"/>
+  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
Recently LAYERCOMPAT was bump to dunfell in master so isn't compatible.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>