### PR TITLE
Fix rpb master CI failures with meta-ti dependency on meta-arm

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -30,6 +30,7 @@ BASELAYERS ?= " \
 
 # These layers hold machine specific content, aka Board Support Packages
 BSPLAYERS ?= " \
+  ${OEROOT}/layers/meta-arm/meta-arm \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \

--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -41,7 +41,6 @@ BSPLAYERS ?= " \
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
   ${OEROOT}/layers/meta-linaro/meta-linaro \
-  ${OEROOT}/layers/meta-linaro/meta-optee \
   ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
 "
 


### PR DESCRIPTION
All master builds are now failing due to meta-ti dependency on meta-arm. So add the layer

https://ci.linaro.org/view/reference-platform/job/rpb-openembedded-master/1331/DISTRO=rpb-wayland,MACHINE=imx8mqevk,label=docker-stretch-amd64/console