### PR TITLE
default.xml: meta-ti use Zeus branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="96boards/meta-rpb" path="layers/meta-rpb" remote="github"/>
   <project name="Freescale/meta-freescale" path="layers/meta-freescale" remote="github"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="master"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto"/>
   <project name="96boards/oe-rpb-manifest" path="conf" remote="github">
     <linkfile dest="setup-environment" src="setup-environment-internal"/>
   </project>


### PR DESCRIPTION
To fix ci zeus failures, as meta-ti master is now dependent
on meta-arm layer.

Signed-off-by: Peter Griffin <peter.griffin@linaro.org>