### PR TITLE
default.xml: fix meta-selinux revision for dunfell

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -18,7 +18,7 @@
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
   <project name="git/meta-arm" path="layers/meta-arm" remote="yocto"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
-  <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto" revision="master"/>
+  <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
   <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="master"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>


### PR DESCRIPTION
With fb15056ff4431 ("libselinux-python: inherit python3targetconfig")
meta-selinux layer broke compatibility with dunfell's oe-core. Fix
meta-selinux to the revision previous to breakage.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
Change-Id: Id1f2c1bf2ab6c9b74a14ef65f4de3f8bd135a833