### PR TITLE
conf/bblayers.conf: Update to include meta-chromium

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -20,7 +20,7 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-rust \
-  ${OEROOT}/layers/meta-browser \
+  ${OEROOT}/layers/meta-browser/meta-chromium \
   ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \


### PR DESCRIPTION
The meta-browser layer splits into two layers meta-chromium and
meta-firefox.

https://github.com/OSSystems/meta-browser/commit/1cf4e02d7107c50c58061f77015c498d8ee09259

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 82812c440846e5a23f6ae52fa5431c3846ba8f9d)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>