### PR TITLE
local.conf: switch to new style of overrides

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -1,12 +1,12 @@
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly
-CONF_VERSION = "1"
+CONF_VERSION = "2"
 
 # Which files do we want to parse:
 BBMASK = ""
 
 # What kind of images do we want?
-IMAGE_FSTYPES_append = " tar.xz"
+IMAGE_FSTYPES:append = " tar.xz"
 
 # Don't generate the mirror tarball for SCM repos, the snapshot is enough
 BB_GENERATE_MIRROR_TARBALLS = "0"


### PR DESCRIPTION
Use new overrides style instead of the old one to become compatible with
hanister. Note, this breaks compatibility with older OE branches.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>