### PR TITLE
Remove meta-selinux from the layers to be included for now

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -24,7 +24,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \
-  ${OEROOT}/layers/meta-selinux \
   ${OEROOT}/layers/meta-python2 \
 "
 

--- a/default.xml
+++ b/default.xml
@@ -16,7 +16,7 @@
   </project>
   <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github"/>
   <project name="git/meta-arm" path="layers/meta-arm" remote="yocto"/>
-  <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
+<!--  <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/> -->
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-python2" path="layers/meta-python2" remote="oe"/>


### PR DESCRIPTION
At this moment we are facing an issue with android-tools that
is present on meta-oe and meta-clang/dynamic-layers:

ERROR: Multiple versions of android-tools-conf-configfs are due to be built (/home/builds/oe-rpb-master/build-410c-2/conf/../../layers/meta-openembedded/meta-oe/recipes-devtools/android-tools/android-tools-conf-configfs_1.0.bb
/home/builds/oe-rpb-master/build-410c-2/conf/../../l,ayers/meta-clang/dynamic-layers/selinux/android-tools/android-tools-conf-configfs_1.0.bb). Only one version of a given PN should be built in any given build. You likely need to set PREFERRED_VERSION_android-tools-conf-configfs to select the correct version or don't depend on multiple versions.

After trying to set PREFERRED_VERSION not works due to:

- The dynamic-layers is load after frist parse so a warning is displayed
  about no version 10 is available (meta-clang/dynamic-layers).
- Two recipes with the same versions one in dynamic-layer and other in
  meta-oe.

Fixes,

https://ci.linaro.org/job/lt-qcom-openembedded-rpb-master/DISTRO=rpb,MACHINE=dragonboard-410c,label=docker-buster-amd64/623/console

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>