### PR TITLE
conf/bblayers.conf: disable meta-ti temporarily

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -34,9 +34,9 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
-  ${OEROOT}/layers/meta-ti \
   ${OEROOT}/layers/meta-freescale \
 "
+#  ${OEROOT}/layers/meta-ti  # disabled till it is updated for honister compat
 
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there


### PR DESCRIPTION
The meta-ti layer is till not updated to support honister branch.
Disable it for now to unbreak master branch builds.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>