### PR TITLE
conf/bblayers.conf: restore meta-ti

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -33,9 +33,9 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
+  ${OEROOT}/layers/meta-ti \
   ${OEROOT}/layers/meta-freescale \
 "
-#  ${OEROOT}/layers/meta-ti  # disabled till it is updated for honister compat
 
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there


### PR DESCRIPTION
Since meta-ti has gained compatibility with the honister override
syntax, restore it in the bblayers.conf

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>