### PR TITLE
default.xml: fix meta-ti revision to dunfell

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,7 +19,7 @@
   <project name="git/meta-arm" path="layers/meta-arm" remote="yocto"/>
   <project name="git/meta-intel" path="layers/meta-intel" remote="yocto"/>
   <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
-  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto" revision="master"/>
+  <project name="git/meta-ti" path="layers/meta-ti" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-python2" path="layers/meta-python2" remote="oe"/>


### PR DESCRIPTION
With the commit e21c11b4a444 ("meta-ti: convert to new override syntax
in honister"), the master branch of meta-ti stopped declaring
compatibility with dunfell. Rather than fixing the revision to
f56051c9a8cf ("ti-rtos-firmware: Update PATH to include ti-sci-fw"), the
latest commit from master branch which is still compatible with dunfell,
switch the meta-ti repo to the dunfell (default) branch.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
Change-Id: Id41bc0e76f524fc5725cdb2661a5239002ae9f7a