### PR TITLE
bblayer.conf: follow meta-ti changes

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -32,7 +32,7 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-qcom \
   ${OEROOT}/layers/meta-96boards \
-  ${OEROOT}/layers/meta-ti \
+  ${OEROOT}/layers/meta-ti/meta-ti-bsp \
   ${OEROOT}/layers/meta-freescale \
 "
 


### PR DESCRIPTION
The meta-ti layer got moved into it's own subdir 'meta-ti-bsp'. Follow
this change in the bblayers.conf

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>