### PR TITLE
default.xml: drop meta-linaro

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -34,7 +34,6 @@ BSPLAYERS ?= " \
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there
 EXTRALAYERS ?= " \
-  ${OEROOT}/layers/meta-linaro/meta-linaro \
   ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
 "
 

--- a/default.xml
+++ b/default.xml
@@ -22,7 +22,6 @@
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="ndechesne/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
-  <project name="openembedded/meta-linaro" path="layers/meta-linaro" remote="linaro"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>
 </manifest>


### PR DESCRIPTION
The meta-linaro collection of layers was not receiving significant updates for the last two years. It has been getting odd fixes since May 2020, mostly when one of the layers broke building of RPB. The meta-linaro-toolchain was replaced by meta-arm-toolchain. I think it is time to drop it completely from the RPB manifest.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 0e2bf89f6f2d8c856e1d631571571cb8ed7ee957)