### PR TITLE
local.conf: enable hash equivalence

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -48,3 +48,5 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # generating the feeds
 #PRSERV_HOST = "localhost:0"
 
+BB_SIGNATURE_HANDLER = "OEEquivHash"
+BB_HASHSERVE = "auto"


### PR DESCRIPTION
Enable hash equivalence to speed up repetitive builds. This mechanism detects build tasks that have the same output even though the input signatures (hash) differ and skips rebuilding tasks depending on the detected ones.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit a487addd1aac37c4b8151fec4de6857311536005)
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>