### PR TITLE
Revert ".github: remove kirkstone from daily build"

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -17,6 +17,12 @@ jobs:
       branch: qcom/master
     secrets: inherit
 
+  qcom-kirkstone:
+    uses: 96boards/oe-rpb-manifest/.github/workflows/build-template.yml@qcom/master
+    with:
+      branch: qcom/kirkstone
+    secrets: inherit
+
   qcom-dunfell:
     uses: 96boards/oe-rpb-manifest/.github/workflows/build-template.yml@qcom/master
     with:


### PR DESCRIPTION
This reverts commit 14c610fd3367db4fc621249ac477eb30887c0d9d. Reenable qcom/kirkstone build to make sure that it works properly.

Closes #171