### PR TITLE
CI: stop building for dragonboards / RB5

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -17,7 +17,7 @@ on:
 env:
   MANIFEST_URL: https://github.com/96boards/oe-rpb-manifest.git
   HOST: ubuntu-20.04
-  MACHINES: dragonboard-410c dragonboard-845c qrb5165-rb5 qcom-armv8a qcom-armv7a
+  MACHINES: qcom-armv8a qcom-armv7a
   DISTRO: rpb rpb-wayland
   IMAGES: rpb-console-image rpb-console-image-test
   IMAGES_rpb: rpb-desktop-image rpb-desktop-image-test


### PR DESCRIPTION
We are going to phase out the individual machine configurations. Stop building them in the CI.