### PR TITLE
default.xml: drop revision for meta-rust

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,7 @@
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-python2" path="layers/meta-python2" remote="oe"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
-  <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github" revision="master"/>
+  <project name="meta-rust/meta-rust" path="layers/meta-rust" remote="github"/>
   <project name="Linaro/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github" revision="1.46"/>
   <project name="openembedded/meta-backports" path="layers/meta-backports" remote="linaro"/>


### PR DESCRIPTION
The master version of meta-rust repo has droppped support for dunell. Stick to the 'dunfell' branch, which contains the last commit before dropping dunfell support.

Change-Id: I529eed5770539a679dc4ea563064f71e649982dd