### PR TITLE
Update oe-rpb-manifest to latest meta-qcom changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To run the setup script:
 
 And follow the instructions. If you already know the value for MACHINE and DISTRO, it is possible to set them as environment variables, e.g. 
 
-    $ MACHINE=dragonboard-410c DISTRO=rpb source setup-environment
+    $ MACHINE=qcom-armv8a DISTRO=rpb source setup-environment
 
 ## Build a minimal, console-only image
 

--- a/default.xml
+++ b/default.xml
@@ -23,7 +23,7 @@
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
   <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
-  <project name="Linaro/meta-qcom" path="layers/meta-qcom" remote="github"/>
+  <project name="meta-qcom" path="layers/meta-qcom" remote="yocto"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>
   <project name="openembedded/openembedded-core" path="layers/openembedded-core" remote="github"/>


### PR DESCRIPTION
Point default.xml to the yocoto project.
Once done this repo is still good to produce a useful image.

Also update the example so that MACHINE is valid again.