### PR TITLE
CI: point to google.com for connectivity check

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -53,6 +53,7 @@ jobs:
           local_conf:
             - INHERIT += 'buildstats buildstats-summary'
             - INHERIT:remove = 'rm_work'
+            - CONNECTIVITY_CHECK_URIS = "https://www.google.com/"
           artifacts: []
 
         rpb: &rpb


### PR DESCRIPTION
In our cloud builds sometimes the default connectivity check URL (yoctoproject.org) returns an error. Point it to google.com to make sure that the connectivity check errors are not caused by some yoctoproject.org misconfiguration (or DoS protection).
