### PR TITLE
README.md: Update example to reflect current MACHINE names

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To run the setup script:
 
 And follow the instructions. If you already know the value for MACHINE and DISTRO, it is possible to set them as environment variables, e.g. 
 
-    $ MACHINE=dragonboard-410c DISTRO=rpb source setup-environment
+    $ MACHINE=qcom-armv8a DISTRO=rpb source setup-environment
 
 ## Build a minimal, console-only image
 


### PR DESCRIPTION
The current example gives an invalid MACHINE. meta-qcom has moved to more generic MACHINE types instead of specific board targets.

Give the example most users would be interested in qcom-armv8a.