### PR TITLE
CI: bump actions/setup-python to v5

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: "3.x"
     - name: Install dependencies


### PR DESCRIPTION
Bump actions/setup-python to v5 as pointed out by GH Node.js warning.