### PR TITLE
manifest: lock meta-browser revision to unbreak build

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <project name="96boards/oe-rpb-manifest" path="conf" remote="github" revision="qcom/kirkstone">
     <linkfile dest="setup-environment" src="setup-environment-internal"/>
   </project>
-  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="master"/>
+  <project name="OSSystems/meta-browser" path="layers/meta-browser" remote="github" revision="ea731e8d4fd8a0b40448ea286b2c92824ee591cc"/>
   <project name="git/meta-arm" path="layers/meta-arm" remote="yocto"/>
 <!--  <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/> -->
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>


### PR DESCRIPTION
The master branch of meta-browser broke compatibility with the Kirkstone OE release branch, see the ticket at
https://github.com/OSSystems/meta-browser/issues/789. Lock the revision until the compatibility issue is resolved.