### PR TITLE
Drop qt5 layer

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -20,7 +20,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-browser/meta-chromium \
-  ${OEROOT}/layers/meta-qt5 \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \
 "

--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,6 @@
   <project name="git/meta-selinux" path="layers/meta-selinux" remote="yocto"/>
   <project name="git/meta-virtualization" path="layers/meta-virtualization" remote="yocto"/>
   <project name="kraj/meta-clang" path="layers/meta-clang" remote="github"/>
-  <project name="meta-qt5/meta-qt5" path="layers/meta-qt5" remote="github"/>
   <project name="Linaro/meta-qcom" path="layers/meta-qcom" remote="github"/>
   <project name="openembedded/bitbake" path="bitbake" remote="github"/>
   <project name="openembedded/meta-openembedded" path="layers/meta-openembedded" remote="github"/>


### PR DESCRIPTION
The QT5 layers becomes outdated, it wasn't updated for the WORKDIR ->
UNPACKDIR changes. Other layers don't depend on the QT5, drop it from builds.