### PR TITLE
CI: retain only licenses as build artifacts

### DIFF
--- a/.github/workflows/build-template.yml
+++ b/.github/workflows/build-template.yml
@@ -54,7 +54,7 @@ jobs:
             - INHERIT += 'buildstats buildstats-summary'
             - INHERIT:remove = 'rm_work'
             - CONNECTIVITY_CHECK_URIS = "https://www.google.com/"
-          artifacts: []
+          artifacts: ["licenses"]
 
         rpb: &rpb
           distro: rpb


### PR DESCRIPTION
There is little point in retaining full set of build artifacts for the test builds, which is what the empty "artifacts" config does. Keep just the licences and throw away everything else.